### PR TITLE
typo 目ドッド → メソッド

### DIFF
--- a/translation-ja/upgrade.md
+++ b/translation-ja/upgrade.md
@@ -428,7 +428,7 @@ Markdownのmailableテンプレートのためのデフォルトテーマスタ�
 
 **影響の可能性： 高い**
 
-`Route::redirect`目ドッドは、`302`HTTPステータスコードを返すようになりました。`301`リダイレクションを行う、`permanentRedirect`メソッドが追加されました。
+`Route::redirect`メソッドは、`302`HTTPステータスコードを返すようになりました。`301`リダイレクションを行う、`permanentRedirect`メソッドが追加されました。
 
     // Return a 302 redirect...
     Route::redirect('/foo', '/bar');


### PR DESCRIPTION
5.6から5.6.0へのアップグレード > ルート > Route::redirectメソッド
「目ドッド」を「メソッド」に修正しました。

https://readouble.com/laravel/5.7/ja/upgrade.html