### PR TITLE
誤植

### DIFF
--- a/translation-ja/upgrade.md
+++ b/translation-ja/upgrade.md
@@ -166,7 +166,7 @@ Laravel Passportを使用している場合は、`composer.json`ファイルの`
     // Laravel 5.7
     {{ $foo ?? 'default' }}
 
-### Cacキャッシュhe
+### Cache
 
 **影響の可能性： とても高い**
 


### PR DESCRIPTION
キャッシュの説明の言葉が英語と日本語が入り混じって表示されていたのを英語表示に修正